### PR TITLE
Prometheus grouping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clean:
 	docker run -v$(REPO_DIR)/:/source/ -v$(REPO_DIR)/data/:/data ethereum-testnet-bootstrapper --clean --log-level $(log_level)
 
 # init the testnet dirs and all files needed to later bootstrap the testnet.
-init-testnet:
+init-testnet: clean
 	docker run -v $(REPO_DIR)/:/source/ -v $(REPO_DIR)/data/:/data ethereum-testnet-bootstrapper --config $(config) --init-testnet --log-level $(log_level)
 
 # get an interactive shell into the testnet-bootstrapper

--- a/src/node_watch.py
+++ b/src/node_watch.py
@@ -365,7 +365,7 @@ class NodeWatch:
                 raise Exception(f"Unknown metric: {metric}")
             if interval not in intervals:
                 raise Exception(f"Unknown interval: {interval}")
-            
+
 
             _interval = intervals[interval]
             testnet_monitor.add_action(

--- a/src/node_watch.py
+++ b/src/node_watch.py
@@ -282,7 +282,7 @@ class PrometheusAction(TestnetMonitorAction):
                 return (human_query, cleaned_data)
 
             except requests.exceptions.Timeout:
-                logging.info(f"prometheus query {query} timed out after {timeout_s}, skipping")
+                logging.debug(f"prometheus query {query} timed out after {timeout_s}, skipping")
                 return
 
             except Exception as e:


### PR DESCRIPTION
the clients have diverging naming schemes for metrics, this groups them under common names. also simplifies the log outputs.